### PR TITLE
Fix blank API response bug

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,14 @@ Changelog
 ----------------
 Version 0 (Beta)
 ----------------
+0.3.1 (2018-Nov-25)
+===================
+
+Bug Fixes
+---------
+
+* Fixed bug where Helcim Commerce API may return a blank response
+  field, resulting in coersion of ``None`` to ``'None'``.
 
 0.3.0 (2018-Nov-24)
 ===================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,7 +12,7 @@ Bug Fixes
 ---------
 
 * Fixed bug where Helcim Commerce API may return a blank response
-  field, resulting in coersion of ``None`` to ``'None'``.
+  for a string field, resulting in coersion of ``None`` to ``'None'``.
 
 0.3.0 (2018-Nov-24)
 ===================

--- a/helcim/__init__.py
+++ b/helcim/__init__.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-docstring, invalid-name
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 # Provide DepreciationWarning for older Django versions
 import warnings

--- a/helcim/conversions.py
+++ b/helcim/conversions.py
@@ -256,7 +256,9 @@ def process_api_response(response, raw_request=None, raw_response=None):
 
                 # String Field
                 if api_field.field_type == 's':
-                    processed[new_name] = str(field_value)
+                    processed[new_name] = (
+                        '' if field_value is None else str(field_value)
+                    )
 
                 # Decimal Field
                 elif api_field.field_type == 'c':

--- a/helcim/conversions.py
+++ b/helcim/conversions.py
@@ -257,7 +257,7 @@ def process_api_response(response, raw_request=None, raw_response=None):
                 # String Field
                 if api_field.field_type == 's':
                     processed[new_name] = (
-                        '' if field_value is None else str(field_value)
+                        None if field_value is None else str(field_value)
                     )
 
                 # Decimal Field

--- a/tests/helcim/test_conversions.py
+++ b/tests/helcim/test_conversions.py
@@ -371,6 +371,22 @@ def test_process_api_response_string_field():
     assert response['cc_number'] == '1111********9999'
     assert isinstance(response['cc_number'], str)
 
+@patch('helcim.conversions.FROM_API_FIELDS', MOCK_FROM_API_FIELDS_STRING)
+def test_process_api_response_string_field_none():
+    """Tests that string field can handle a None response."""
+    api_response = {
+        'response': 1,
+        'responseMessage': 'Transaction successful.',
+        'notice': '',
+        'transaction': {
+            'cardNumber': None,
+        }
+    }
+
+    response = conversions.process_api_response(api_response)
+
+    assert response['cc_number'] is None
+
 @patch('helcim.conversions.FROM_API_FIELDS', MOCK_FROM_API_FIELDS_DECIMAL)
 def test_process_api_response_decimal_field():
     api_response = {


### PR DESCRIPTION
Saving the HelcimTransaction causes an error when a blank XML field is returned from the API for a string field. `None` is coerced into `'None'`, which may cause various errors. This fixes that error.