### PR TITLE
Fixing F4L4 bug

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,16 @@ Changelog
 Version 0 (Beta)
 ----------------
 
+0.8.1 (2020-Apr-23)
+===================
+
+Bug Fixes
+---------
+
+* Fixing bug with the Helcim token "First 4 Last 4" characters saving;
+  Helcim.js response may include whitespace in credit card number,
+  so this needs to be stripped out.
+
 0.8.0 (2020-Apr-21)
 ===================
 

--- a/helcim/__init__.py
+++ b/helcim/__init__.py
@@ -6,7 +6,7 @@ import warnings
 import django
 
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 
 # Provide DepreciationWarning for older Python versions
 # Have to use sys.version while supporting Python 3.5 to enable testing

--- a/helcim/conversions.py
+++ b/helcim/conversions.py
@@ -314,7 +314,8 @@ def create_f4l4(cc_number):
             string: the token F4L4 value.
     """
     if cc_number:
-        return '{}{}'.format(cc_number[:4], cc_number[-4:])
+        stripped_cc = cc_number.strip()
+        return '{}{}'.format(stripped_cc[:4], stripped_cc[-4:])
 
     return None
 

--- a/tests/helcim/test_conversions.py
+++ b/tests/helcim/test_conversions.py
@@ -419,6 +419,12 @@ def test__create_f4l4():
 
     assert token_f4l4 == '11119999'
 
+def test__create_f4l4__with_whitespace():
+    """Confirms the F4L4 is returned when cc_number provided."""
+    token_f4l4 = conversions.create_f4l4(' 1111********9999 ')
+
+    assert token_f4l4 == '11119999'
+
 def test__create_f4l4__no_cc():
     """Confirms the F4L4 creation can handle a missing CC number."""
     token_f4l4 = conversions.create_f4l4(None)


### PR DESCRIPTION
Fixing bug with the Helcim token "First 4 Last 4" characters of CC number; Helcim.js response may include whitespace in credit card number, so this needs to be stripped out.