### PR TITLE
Add test input for helcim.js

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,17 @@ Changelog
 Version 0 (Beta)
 ----------------
 
+0.9.0 (2020-Apr-23)
+===================
+
+Feature Updates
+---------------
+
+* Adding new settings key under the ``HELCIM_JS_CONFIG`` setting.
+  Can now include ``test: True`` for each Helcim.js configuration.
+  When enabled, you can use ``helcim_js.identifier.test_input`` to
+  enable or disable test mode within the Django template.
+
 0.8.1 (2020-Apr-23)
 ===================
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -83,15 +83,43 @@ the following format:
 .. code-block:: python
 
    {
-     'custom_identifier': {
+     'identifier': {
        'url': 'url-to-your-helcim-js-script',
        'token' 'your-helcim-js-token',
+       'test': True,
      }
    }
 
 Once configured, you can add the ``HelcimJSMixin`` to the required views and
-access the details in your templates through this syntax:
-``helcim_js.custom_identifier.url`` and ``helcim_js.custom_identifier.token``.
+access the details in your templates. Below is summary of the keys and mixin
+funtionality:
+
++----------------+-----------------------+------------------------------------+
+| Settings Key   | Description           | Mixin Usage                        |
++================+=======================+====================================+
+| ``identifier`` | An identifier used in | ``helcim_js.identifier``           |
+|                | templates to          |                                    |
+|                | reference these       |                                    |
+|                | configuration         |                                    |
+|                | details.              |                                    |
++----------------+-----------------------+------------------------------------+
+| ``url``        | URL to the Helcim.js  | ``helcim_js.identifier.url``       |
+|                | file. Can be an empty |                                    |
+|                | string if you will    |                                    |
+|                | serve the JS file     |                                    |
+|                | yourself.             |                                    |
++----------------+-----------------------+------------------------------------+
+| ``token``      | The Helcim.js token   | ``helcim_js.identifier.token``     |
++----------------+-----------------------+------------------------------------+
+| ``test``       | Optional value; add   | ``helcim_js.identifier.test_input` |
+|                | key with a ``truthy`` |                                    |
+|                | value to enable. If   |                                    |
+|                | enabled, will output  |                                    |
+|                | the HTML input to     |                                    |
+|                | trigger the Helcim.js |                                    |
+|                | test mode. Otherwise  |                                    |
+|                | will be empty string. |                                    |
++----------------+-----------------------+------------------------------------+
 
 -----------------------------
 Private data storage settings

--- a/helcim/__init__.py
+++ b/helcim/__init__.py
@@ -6,7 +6,7 @@ import warnings
 import django
 
 
-__version__ = '0.8.1'
+__version__ = '0.9.0'
 
 # Provide DepreciationWarning for older Python versions
 # Have to use sys.version while supporting Python 3.5 to enable testing

--- a/helcim/mixins.py
+++ b/helcim/mixins.py
@@ -391,4 +391,16 @@ class HelcimJSMixin():
         # Add the Helcim.js configuration details
         context['helcim_js'] = SETTINGS['helcim_js']
 
+        # Add a helper "test" input to allow declaration of test status
+        # This input flags a transaction as a test and allows testing
+        # in environments without SSL enabled (e.g. the Django
+        # development server)
+        for config in context['helcim_js']:
+            if context['helcim_js'][config].get('test', False):
+                test_input = '<input id="test" type="hidden" value="1">'
+            else:
+                test_input = ''
+
+            context['helcim_js'][config]['test_input'] = test_input
+
         return context

--- a/tests/helcim/test_mixins.py
+++ b/tests/helcim/test_mixins.py
@@ -913,7 +913,7 @@ def test__response__save_token__with_customer_code():
     assert token_instance.data['token_f4l4'] == '11119999'
     assert token_instance.data['customer_code'] == 'CST1000'
 
-@patch.dict('helcim.mixins.SETTINGS', {'helcim_js': 'abc'})
+@patch.dict('helcim.mixins.SETTINGS', {'helcim_js': {'id': {'url': 'abc'}}})
 def test__helcim_js_mixin__adds_context():
     """Confirms that expected context is added with mixin."""
     django_view = MockMixinView()
@@ -921,4 +921,36 @@ def test__helcim_js_mixin__adds_context():
     context = django_view.get_context_data()
 
     assert 'helcim_js' in context
-    assert context['helcim_js'] == 'abc'
+    assert context['helcim_js'] == {'id': {'url': 'abc', 'test_input': ''}}
+
+@patch.dict('helcim.mixins.SETTINGS', {'helcim_js': {'id': {'test': True}}})
+def test__helcim_js_mixin__adds_test_input__with_test_key():
+    """Confirms an HTML test input is added when test key specified."""
+    django_view = MockMixinView()
+
+    context = django_view.get_context_data()
+
+    assert 'test_input' in context['helcim_js']['id']
+    assert context['helcim_js']['id']['test_input'] == (
+        '<input id="test" type="hidden" value="1">'
+    )
+
+@patch.dict('helcim.mixins.SETTINGS', {'helcim_js': {'id': {}}})
+def test__helcim_js_mixin__doesadds_test_input__without_test_key():
+    """Confirms empty string returned when test key not specified."""
+    django_view = MockMixinView()
+
+    context = django_view.get_context_data()
+
+    assert 'test_input' in context['helcim_js']['id']
+    assert context['helcim_js']['id']['test_input'] == ''
+
+@patch.dict('helcim.mixins.SETTINGS', {'helcim_js': {'id': {'test': False}}})
+def test__helcim_js_mixin__doesadds_test_input__with_falsy_key():
+    """Confirms empty string returned when test key is a falsy value."""
+    django_view = MockMixinView()
+
+    context = django_view.get_context_data()
+
+    assert 'test_input' in context['helcim_js']['id']
+    assert context['helcim_js']['id']['test_input'] == ''


### PR DESCRIPTION
Allows easy declaration and configuration of test modes without having to modify template